### PR TITLE
Exclude examples folder in npm releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "",
   "main": "bolt11.js",
+  "files": ["*.js"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fiatjaf/light-bolt11-decoder.git"


### PR DESCRIPTION
The `files` entry in `package.json` excludes the `examples` folder in the npm package. This reduces dependencies on projects that have `light-bolt11-decoder` as a dependency.