### PR TITLE
Add ability to decode signet

### DIFF
--- a/bolt11.js
+++ b/bolt11.js
@@ -14,6 +14,12 @@ const TESTNETWORK = {
   scriptHash: 0xc4,
   validWitnessVersions: [0]
 }
+const SIGNETNETWORK = {
+	bech32: 'tbs',
+	pubKeyHash: 0x6f,
+	scriptHash: 0xc4,
+	validWitnessVersions: [0]
+}
 const REGTESTNETWORK = {
   bech32: 'bcrt',
   pubKeyHash: 0x6f,
@@ -252,6 +258,9 @@ function decode(paymentRequest, network) {
       case TESTNETWORK.bech32:
         coinNetwork = TESTNETWORK
         break
+      case SIGNETNETWORK.bech32:
+				coinNetwork = SIGNETNETWORK;
+				break
       case REGTESTNETWORK.bech32:
         coinNetwork = REGTESTNETWORK
         break


### PR DESCRIPTION
Currently, decoding signet bolt11 payment requests fails with the error:
```
Unknown coin bech32 prefix
```

Signet payment requests have a prefix of `tbs`, which currently isn't handled. This PR adds the ability to handle signet payment requests by matching on the `tbs` prefix.